### PR TITLE
fix: 座標リストの選択機能を修正

### DIFF
--- a/3/index.html
+++ b/3/index.html
@@ -132,6 +132,8 @@
         
         // 座標を選択する関数
         function selectCoordinate(index) {
+            const list = document.getElementById('coordinateList');
+            
             // 前の選択を解除
             if (selectedIndex >= 0) {
                 list.children[selectedIndex].classList.remove('selected');


### PR DESCRIPTION
## Summary
- 架空の世界地図座標プロッターの左側座標リストが選択できない問題を修正
- selectCoordinate関数内でDOM要素を正しく取得するように変更
- 矢印キーでの上下移動機能が正常に動作するように

## Test plan
- [ ] 左側の座標リストをクリックして選択できることを確認
- [ ] 選択した座標が緑色でハイライトされることを確認
- [ ] 矢印キーの上下で座標リスト間を移動できることを確認
- [ ] 選択時に地図が該当座標にズームすることを確認
- [ ] ポップアップが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)