### PR TITLE
feat: 画像編集ツール「架空のPhotoFilter Studio」を追加

### DIFF
--- a/12/index.html
+++ b/12/index.html
@@ -1,0 +1,600 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>架空の画像編集ツール - PhotoFilter Studio</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 20px;
+        }
+
+        .header {
+            text-align: center;
+            color: white;
+            margin-bottom: 30px;
+        }
+
+        .header h1 {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+        }
+
+        .header p {
+            font-size: 1.1rem;
+            opacity: 0.95;
+        }
+
+        .main-container {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+            padding: 30px;
+            max-width: 1200px;
+            width: 100%;
+        }
+
+        .upload-area {
+            border: 3px dashed #667eea;
+            border-radius: 15px;
+            padding: 40px;
+            text-align: center;
+            background: #f8f9ff;
+            transition: all 0.3s ease;
+            cursor: pointer;
+            margin-bottom: 30px;
+        }
+
+        .upload-area.dragover {
+            background: #e8ebff;
+            border-color: #764ba2;
+            transform: scale(1.02);
+        }
+
+        .upload-area.has-image {
+            display: none;
+        }
+
+        .upload-icon {
+            font-size: 3rem;
+            color: #667eea;
+            margin-bottom: 20px;
+        }
+
+        .upload-text {
+            color: #666;
+            font-size: 1.2rem;
+            margin-bottom: 10px;
+        }
+
+        .upload-subtext {
+            color: #999;
+            font-size: 0.9rem;
+        }
+
+        input[type="file"] {
+            display: none;
+        }
+
+        .editor-container {
+            display: none;
+            grid-template-columns: 1fr 350px;
+            gap: 30px;
+            align-items: start;
+        }
+
+        .editor-container.active {
+            display: grid;
+        }
+
+        .preview-container {
+            background: #f5f5f5;
+            border-radius: 10px;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .canvas-wrapper {
+            position: relative;
+            margin-bottom: 20px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+
+        canvas {
+            display: block;
+            max-width: 100%;
+            height: auto;
+        }
+
+        .controls-panel {
+            background: #f8f9ff;
+            border-radius: 10px;
+            padding: 25px;
+        }
+
+        .control-group {
+            margin-bottom: 25px;
+        }
+
+        .control-label {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 10px;
+            font-size: 0.95rem;
+        }
+
+        .control-value {
+            color: #667eea;
+            font-weight: normal;
+            font-size: 0.9rem;
+        }
+
+        .slider {
+            width: 100%;
+            height: 8px;
+            border-radius: 4px;
+            background: #ddd;
+            outline: none;
+            -webkit-appearance: none;
+            cursor: pointer;
+        }
+
+        .slider::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            background: #667eea;
+            cursor: pointer;
+            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4);
+            transition: transform 0.2s;
+        }
+
+        .slider::-webkit-slider-thumb:hover {
+            transform: scale(1.2);
+        }
+
+        .slider::-moz-range-thumb {
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            background: #667eea;
+            cursor: pointer;
+            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4);
+            transition: transform 0.2s;
+        }
+
+        .slider::-moz-range-thumb:hover {
+            transform: scale(1.2);
+        }
+
+        .hue-slider {
+            background: linear-gradient(to right, 
+                hsl(0, 100%, 50%) 0%, 
+                hsl(60, 100%, 50%) 17%, 
+                hsl(120, 100%, 50%) 33%, 
+                hsl(180, 100%, 50%) 50%, 
+                hsl(240, 100%, 50%) 67%, 
+                hsl(300, 100%, 50%) 83%, 
+                hsl(360, 100%, 50%) 100%);
+        }
+
+        .action-buttons {
+            display: flex;
+            gap: 15px;
+            margin-top: 30px;
+            padding-top: 25px;
+            border-top: 2px solid #e5e5e5;
+        }
+
+        .btn {
+            flex: 1;
+            padding: 12px 20px;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+        }
+
+        .btn-secondary {
+            background: #f5f5f5;
+            color: #666;
+        }
+
+        .btn-secondary:hover {
+            background: #e8e8e8;
+        }
+
+        .loading {
+            display: none;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            color: #667eea;
+            font-size: 1.2rem;
+        }
+
+        @media (max-width: 768px) {
+            .editor-container {
+                grid-template-columns: 1fr;
+            }
+            
+            .header h1 {
+                font-size: 2rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🎨 架空の PhotoFilter Studio</h1>
+        <p>画像をドラッグ&ドロップして、色調整を楽しもう！</p>
+    </div>
+
+    <div class="main-container">
+        <div class="upload-area" id="uploadArea">
+            <div class="upload-icon">📸</div>
+            <div class="upload-text">画像をドラッグ&ドロップ</div>
+            <div class="upload-subtext">または クリックして選択</div>
+            <input type="file" id="fileInput" accept="image/*">
+        </div>
+
+        <div class="editor-container" id="editorContainer">
+            <div class="preview-container">
+                <div class="canvas-wrapper">
+                    <canvas id="canvas"></canvas>
+                    <div class="loading" id="loading">処理中...</div>
+                </div>
+                <button class="btn btn-secondary" id="newImageBtn">別の画像を選択</button>
+            </div>
+
+            <div class="controls-panel">
+                <div class="control-group">
+                    <label class="control-label">
+                        <span>🎨 色相（Hue）</span>
+                        <span class="control-value" id="hueValue">0°</span>
+                    </label>
+                    <input type="range" class="slider hue-slider" id="hueSlider" min="-180" max="180" value="0">
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label">
+                        <span>🌈 彩度（Saturation）</span>
+                        <span class="control-value" id="saturationValue">100%</span>
+                    </label>
+                    <input type="range" class="slider" id="saturationSlider" min="0" max="200" value="100">
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label">
+                        <span>☀️ 明度（Brightness）</span>
+                        <span class="control-value" id="brightnessValue">100%</span>
+                    </label>
+                    <input type="range" class="slider" id="brightnessSlider" min="0" max="200" value="100">
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label">
+                        <span>⚡ コントラスト</span>
+                        <span class="control-value" id="contrastValue">100%</span>
+                    </label>
+                    <input type="range" class="slider" id="contrastSlider" min="0" max="200" value="100">
+                </div>
+
+                <div class="control-group">
+                    <label class="control-label">
+                        <span>🌡️ 色温度</span>
+                        <span class="control-value" id="temperatureValue">0</span>
+                    </label>
+                    <input type="range" class="slider" id="temperatureSlider" min="-100" max="100" value="0">
+                </div>
+
+                <div class="action-buttons">
+                    <button class="btn btn-secondary" id="resetBtn">リセット</button>
+                    <button class="btn btn-primary" id="downloadBtn">ダウンロード</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const uploadArea = document.getElementById('uploadArea');
+        const fileInput = document.getElementById('fileInput');
+        const editorContainer = document.getElementById('editorContainer');
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        const newImageBtn = document.getElementById('newImageBtn');
+        const resetBtn = document.getElementById('resetBtn');
+        const downloadBtn = document.getElementById('downloadBtn');
+        
+        let originalImage = null;
+        let currentImage = new Image();
+
+        // スライダー要素
+        const sliders = {
+            hue: document.getElementById('hueSlider'),
+            saturation: document.getElementById('saturationSlider'),
+            brightness: document.getElementById('brightnessSlider'),
+            contrast: document.getElementById('contrastSlider'),
+            temperature: document.getElementById('temperatureSlider')
+        };
+
+        // 値表示要素
+        const values = {
+            hue: document.getElementById('hueValue'),
+            saturation: document.getElementById('saturationValue'),
+            brightness: document.getElementById('brightnessValue'),
+            contrast: document.getElementById('contrastValue'),
+            temperature: document.getElementById('temperatureValue')
+        };
+
+        // ドラッグ&ドロップ処理
+        uploadArea.addEventListener('click', () => fileInput.click());
+
+        uploadArea.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            uploadArea.classList.add('dragover');
+        });
+
+        uploadArea.addEventListener('dragleave', () => {
+            uploadArea.classList.remove('dragover');
+        });
+
+        uploadArea.addEventListener('drop', (e) => {
+            e.preventDefault();
+            uploadArea.classList.remove('dragover');
+            
+            const files = e.dataTransfer.files;
+            if (files.length > 0) {
+                handleFile(files[0]);
+            }
+        });
+
+        fileInput.addEventListener('change', (e) => {
+            if (e.target.files.length > 0) {
+                handleFile(e.target.files[0]);
+            }
+        });
+
+        // ファイル処理
+        function handleFile(file) {
+            if (!file.type.startsWith('image/')) {
+                alert('画像ファイルを選択してください');
+                return;
+            }
+
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                currentImage.onload = () => {
+                    canvas.width = currentImage.width;
+                    canvas.height = currentImage.height;
+                    ctx.drawImage(currentImage, 0, 0);
+                    
+                    // オリジナル画像データを保存
+                    originalImage = ctx.getImageData(0, 0, canvas.width, canvas.height);
+                    
+                    uploadArea.classList.add('has-image');
+                    editorContainer.classList.add('active');
+                    
+                    // キャンバスのサイズ調整
+                    fitCanvasToContainer();
+                };
+                currentImage.src = e.target.result;
+            };
+            reader.readAsDataURL(file);
+        }
+
+        // キャンバスのサイズ調整
+        function fitCanvasToContainer() {
+            const maxWidth = 600;
+            const scale = Math.min(1, maxWidth / canvas.width);
+            canvas.style.width = (canvas.width * scale) + 'px';
+            canvas.style.height = (canvas.height * scale) + 'px';
+        }
+
+        // 画像フィルター適用
+        function applyFilters() {
+            if (!originalImage) return;
+
+            const imageData = ctx.createImageData(originalImage.width, originalImage.height);
+            const data = imageData.data;
+            const original = originalImage.data;
+
+            const hue = parseFloat(sliders.hue.value);
+            const saturation = parseFloat(sliders.saturation.value) / 100;
+            const brightness = parseFloat(sliders.brightness.value) / 100;
+            const contrast = parseFloat(sliders.contrast.value) / 100;
+            const temperature = parseFloat(sliders.temperature.value);
+
+            for (let i = 0; i < original.length; i += 4) {
+                let r = original[i];
+                let g = original[i + 1];
+                let b = original[i + 2];
+
+                // RGB to HSL
+                let [h, s, l] = rgbToHsl(r, g, b);
+
+                // 色相調整
+                h = (h + hue + 360) % 360;
+
+                // 彩度調整
+                s = Math.min(1, s * saturation);
+
+                // HSL to RGB
+                [r, g, b] = hslToRgb(h, s, l);
+
+                // 明度調整
+                r = Math.min(255, r * brightness);
+                g = Math.min(255, g * brightness);
+                b = Math.min(255, b * brightness);
+
+                // コントラスト調整
+                r = Math.min(255, Math.max(0, ((r - 128) * contrast) + 128));
+                g = Math.min(255, Math.max(0, ((g - 128) * contrast) + 128));
+                b = Math.min(255, Math.max(0, ((b - 128) * contrast) + 128));
+
+                // 色温度調整
+                if (temperature > 0) {
+                    r = Math.min(255, r + temperature);
+                    b = Math.max(0, b - temperature);
+                } else {
+                    r = Math.max(0, r + temperature);
+                    b = Math.min(255, b - temperature);
+                }
+
+                data[i] = r;
+                data[i + 1] = g;
+                data[i + 2] = b;
+                data[i + 3] = original[i + 3];
+            }
+
+            ctx.putImageData(imageData, 0, 0);
+        }
+
+        // RGB to HSL変換
+        function rgbToHsl(r, g, b) {
+            r /= 255;
+            g /= 255;
+            b /= 255;
+
+            const max = Math.max(r, g, b);
+            const min = Math.min(r, g, b);
+            let h, s, l = (max + min) / 2;
+
+            if (max === min) {
+                h = s = 0;
+            } else {
+                const d = max - min;
+                s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+                switch (max) {
+                    case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+                    case g: h = ((b - r) / d + 2) / 6; break;
+                    case b: h = ((r - g) / d + 4) / 6; break;
+                }
+            }
+
+            return [h * 360, s, l];
+        }
+
+        // HSL to RGB変換
+        function hslToRgb(h, s, l) {
+            h /= 360;
+            let r, g, b;
+
+            if (s === 0) {
+                r = g = b = l;
+            } else {
+                const hue2rgb = (p, q, t) => {
+                    if (t < 0) t += 1;
+                    if (t > 1) t -= 1;
+                    if (t < 1/6) return p + (q - p) * 6 * t;
+                    if (t < 1/2) return q;
+                    if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+                    return p;
+                };
+
+                const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+                const p = 2 * l - q;
+
+                r = hue2rgb(p, q, h + 1/3);
+                g = hue2rgb(p, q, h);
+                b = hue2rgb(p, q, h - 1/3);
+            }
+
+            return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+        }
+
+        // スライダーイベント
+        Object.keys(sliders).forEach(key => {
+            sliders[key].addEventListener('input', () => {
+                updateValueDisplay(key);
+                applyFilters();
+            });
+        });
+
+        // 値表示の更新
+        function updateValueDisplay(key) {
+            const value = sliders[key].value;
+            switch(key) {
+                case 'hue':
+                    values[key].textContent = `${value}°`;
+                    break;
+                case 'temperature':
+                    values[key].textContent = value;
+                    break;
+                default:
+                    values[key].textContent = `${value}%`;
+            }
+        }
+
+        // リセット処理
+        resetBtn.addEventListener('click', () => {
+            sliders.hue.value = 0;
+            sliders.saturation.value = 100;
+            sliders.brightness.value = 100;
+            sliders.contrast.value = 100;
+            sliders.temperature.value = 0;
+
+            Object.keys(sliders).forEach(key => updateValueDisplay(key));
+            
+            if (originalImage) {
+                ctx.putImageData(originalImage, 0, 0);
+            }
+        });
+
+        // ダウンロード処理
+        downloadBtn.addEventListener('click', () => {
+            const link = document.createElement('a');
+            link.download = 'edited-image.png';
+            link.href = canvas.toDataURL();
+            link.click();
+        });
+
+        // 新しい画像を選択
+        newImageBtn.addEventListener('click', () => {
+            fileInput.value = '';
+            uploadArea.classList.remove('has-image');
+            editorContainer.classList.remove('active');
+            originalImage = null;
+            
+            // スライダーをリセット
+            resetBtn.click();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ドラッグ&ドロップで画像をアップロードして色調整ができるツールを実装
- 色相（Hue）スライダーで赤・青・ピンクなど様々な色に変更可能
- リアルタイムプレビューと編集済み画像のダウンロード機能を搭載

## Features
- 🎨 **色相調整**: -180°〜180°の範囲で色相を変更（赤、青、ピンクなど）
- 🌈 **彩度調整**: 0%〜200%の範囲で鮮やかさを調整
- ☀️ **明度調整**: 0%〜200%の範囲で明るさを調整
- ⚡ **コントラスト調整**: 0%〜200%の範囲でメリハリを調整
- 🌡️ **色温度調整**: -100〜100の範囲で暖色/寒色を調整
- 📸 **ドラッグ&ドロップ対応**: 画像を簡単にアップロード
- 💾 **ダウンロード機能**: 編集した画像をPNG形式で保存

## Test plan
- [ ] 12/index.htmlをブラウザで開く
- [ ] 画像をドラッグ&ドロップでアップロードできることを確認
- [ ] 各スライダーが正常に動作し、リアルタイムでプレビューが更新されることを確認
- [ ] 色相スライダーで画像の色を変更できることを確認
- [ ] リセットボタンで全ての値が初期状態に戻ることを確認
- [ ] ダウンロードボタンで編集済み画像が保存できることを確認
- [ ] レスポンシブデザインが機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)