### PR TITLE
fix: 11/index.htmlの全ボタンをクリック可能に修正

### DIFF
--- a/11/index.html
+++ b/11/index.html
@@ -540,6 +540,7 @@
                 e.preventDefault();
                 document.querySelectorAll('.nav-item').forEach(i => i.classList.remove('active'));
                 item.classList.add('active');
+                alert(`架空のナビゲーション: ${item.querySelector('span:last-child').textContent}へ移動`);
             });
         });
 
@@ -547,6 +548,8 @@
             card.addEventListener('click', () => {
                 document.querySelectorAll('.model-card').forEach(c => c.classList.remove('selected'));
                 card.classList.add('selected');
+                const modelName = card.querySelector('.model-name').textContent;
+                alert(`架空のモデル選択: ${modelName}を選択しました`);
             });
         });
 
@@ -555,10 +558,34 @@
         });
 
         document.querySelectorAll('.btn-primary').forEach(btn => {
-            btn.addEventListener('click', () => {
-                alert('架空の機能です - 実際には動作しません');
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const btnText = btn.textContent.trim();
+                alert(`架空の機能: ${btnText} - 実際には動作しません`);
             });
         });
+
+        document.querySelectorAll('.btn-secondary').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const btnText = btn.textContent.trim();
+                
+                if (btn.tagName === 'SELECT') {
+                    const selectedOption = btn.options[btn.selectedIndex].text;
+                    alert(`架空の表示切替: ${selectedOption}を選択しました`);
+                } else {
+                    alert(`架空の機能: ${btnText} - 実際には動作しません`);
+                }
+            });
+        });
+
+        const selectElement = document.querySelector('select.btn.btn-secondary');
+        if (selectElement) {
+            selectElement.addEventListener('change', (e) => {
+                const selectedOption = e.target.options[e.target.selectedIndex].text;
+                alert(`架空のグラフ表示: ${selectedOption}に切り替えました`);
+            });
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- 11/index.html内の全てのボタンとインタラクティブ要素をクリック可能に修正
- 各要素にそれぞれ適切なアラートメッセージを表示するように改善

## 修正内容
- ✅ ナビゲーションメニューのクリック時にアラート表示を追加
- ✅ モデルカード選択時に選択したモデル名を表示
- ✅ btn-secondaryクラスのボタン（「管理」ボタン）にイベントリスナーを追加
- ✅ selectドロップダウンの変更イベントを追加
- ✅ 全てのインタラクティブ要素が動作するように改善

## Test plan
- [ ] ブラウザで11/index.htmlを開く
- [ ] サイドバーのナビゲーションメニューをクリックして、アラートが表示されることを確認
- [ ] 「新規プロジェクト」ボタンをクリックして、アラートが表示されることを確認
- [ ] 「新規APIキー作成」ボタンをクリックして、アラートが表示されることを確認
- [ ] APIキーの「管理」ボタンをクリックして、アラートが表示されることを確認
- [ ] 使用量グラフのドロップダウンを変更して、アラートが表示されることを確認
- [ ] モデルカードをクリックして、選択状態が変わりアラートが表示されることを確認
- [ ] ユーザーメニューをクリックして、アラートが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)