### PR TITLE
fix: 画像トリミングツールのUXを大幅改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+.env
+.DS_Store

--- a/15/index.html
+++ b/15/index.html
@@ -217,9 +217,16 @@
         
         .crop-overlay {
             position: absolute;
-            border: 2px solid #667eea;
-            background: rgba(102, 126, 234, 0.2);
+            border: 3px dashed #667eea;
+            background: rgba(102, 126, 234, 0.15);
             pointer-events: none;
+            box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
+            animation: pulse 1s ease-in-out infinite;
+        }
+        
+        @keyframes pulse {
+            0%, 100% { border-color: #667eea; }
+            50% { border-color: #764ba2; }
         }
         
         .crop-handle {
@@ -276,6 +283,60 @@
         
         input[type="file"] {
             display: none;
+        }
+        
+        .crop-mode-indicator {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 12px 24px;
+            border-radius: 30px;
+            font-weight: bold;
+            z-index: 1000;
+            display: none;
+            animation: slideIn 0.3s ease;
+            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+        }
+        
+        .crop-mode-indicator.active {
+            display: block;
+        }
+        
+        @keyframes slideIn {
+            from {
+                transform: translateX(100%);
+                opacity: 0;
+            }
+            to {
+                transform: translateX(0);
+                opacity: 1;
+            }
+        }
+        
+        .crop-instructions {
+            position: fixed;
+            bottom: 80px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.9);
+            color: white;
+            padding: 15px 30px;
+            border-radius: 10px;
+            font-size: 14px;
+            z-index: 1000;
+            display: none;
+            animation: fadeIn 0.5s ease;
+        }
+        
+        .crop-instructions.active {
+            display: block;
+        }
+        
+        @keyframes fadeIn {
+            from { opacity: 0; }
+            to { opacity: 1; }
         }
     </style>
 </head>
@@ -345,15 +406,26 @@
         </div>
     </div>
     
+    <div class="crop-mode-indicator" id="cropModeIndicator">
+        🎯 トリミングモード
+    </div>
+    
+    <div class="crop-instructions" id="cropInstructions">
+        📐 マウスでドラッグして範囲を選択してください
+    </div>
+    
     <script>
         class ImageTrimmer {
             constructor() {
                 this.originalImage = null;
                 this.currentImage = null;
+                this.beforeCropImage = null;
                 this.canvas = document.getElementById('canvas');
                 this.ctx = this.canvas.getContext('2d');
                 this.cropArea = null;
                 this.isDragging = false;
+                this.isCropMode = false;
+                this.isShowingOriginal = false;
                 this.dragStart = null;
                 this.quality = 0.85;
                 
@@ -492,12 +564,18 @@
             
             startFreeCrop() {
                 this.cropArea = null;
+                this.isCropMode = true;
                 document.getElementById('cropOverlay').style.display = 'none';
+                document.getElementById('cropModeIndicator').classList.add('active');
+                document.getElementById('cropInstructions').classList.add('active');
                 this.canvas.style.cursor = 'crosshair';
+                
+                // 確定ボタンとキャンセルボタンを表示
+                this.showCropControls();
             }
             
             startCrop(e) {
-                if (!this.currentImage) return;
+                if (!this.currentImage || !this.isCropMode) return;
                 
                 const rect = this.canvas.getBoundingClientRect();
                 this.isDragging = true;
@@ -512,6 +590,9 @@
                 overlay.style.top = this.dragStart.y + 'px';
                 overlay.style.width = '0px';
                 overlay.style.height = '0px';
+                
+                // 指示を更新
+                document.getElementById('cropInstructions').textContent = '📐 範囲を調整中... ドラッグして範囲を指定';
             }
             
             updateCrop(e) {
@@ -539,12 +620,61 @@
             endCrop() {
                 this.isDragging = false;
                 if (this.cropArea && this.cropArea.width > 10 && this.cropArea.height > 10) {
-                    this.applyCrop();
+                    // 範囲選択完了、確定待ち
+                    document.getElementById('cropInstructions').innerHTML = 
+                        '✅ 範囲選択完了！<br>「トリミング確定」ボタンで実行 or 「キャンセル」で中止';
+                    this.showCropButtons();
                 }
             }
             
-            applyCrop() {
+            showCropControls() {
+                // 既存のボタンを非表示
+                const existingButtons = document.getElementById('cropControlButtons');
+                if (existingButtons) {
+                    existingButtons.remove();
+                }
+            }
+            
+            showCropButtons() {
+                // 既存のボタンを削除
+                const existingButtons = document.getElementById('cropControlButtons');
+                if (existingButtons) {
+                    existingButtons.remove();
+                }
+                
+                // 新しいボタンコントロールを作成
+                const controlDiv = document.createElement('div');
+                controlDiv.id = 'cropControlButtons';
+                controlDiv.style.cssText = `
+                    position: fixed;
+                    bottom: 140px;
+                    left: 50%;
+                    transform: translateX(-50%);
+                    display: flex;
+                    gap: 15px;
+                    z-index: 1001;
+                `;
+                
+                const confirmBtn = document.createElement('button');
+                confirmBtn.textContent = '✂️ トリミング確定';
+                confirmBtn.className = 'btn btn-success';
+                confirmBtn.onclick = () => this.confirmCrop();
+                
+                const cancelBtn = document.createElement('button');
+                cancelBtn.textContent = '❌ キャンセル';
+                cancelBtn.className = 'btn btn-secondary';
+                cancelBtn.onclick = () => this.cancelCrop();
+                
+                controlDiv.appendChild(confirmBtn);
+                controlDiv.appendChild(cancelBtn);
+                document.body.appendChild(controlDiv);
+            }
+            
+            confirmCrop() {
                 if (!this.cropArea) return;
+                
+                // 元画像を保存（比較用）
+                this.beforeCropImage = this.currentImage;
                 
                 const tempCanvas = document.createElement('canvas');
                 const tempCtx = tempCanvas.getContext('2d');
@@ -570,10 +700,55 @@
                 img.onload = () => {
                     this.currentImage = img;
                     this.displayImage(img);
-                    document.getElementById('cropOverlay').style.display = 'none';
-                    this.cropArea = null;
+                    this.exitCropMode();
+                    this.showComparisonButton();
                 };
                 img.src = tempCanvas.toDataURL('image/jpeg', this.quality);
+            }
+            
+            cancelCrop() {
+                this.exitCropMode();
+            }
+            
+            exitCropMode() {
+                this.isCropMode = false;
+                this.cropArea = null;
+                document.getElementById('cropOverlay').style.display = 'none';
+                document.getElementById('cropModeIndicator').classList.remove('active');
+                document.getElementById('cropInstructions').classList.remove('active');
+                this.canvas.style.cursor = 'default';
+                
+                // コントロールボタンを削除
+                const controlButtons = document.getElementById('cropControlButtons');
+                if (controlButtons) {
+                    controlButtons.remove();
+                }
+            }
+            
+            showComparisonButton() {
+                // 比較ボタンを追加（まだ存在しない場合）
+                if (!document.getElementById('compareBtn')) {
+                    const toolbar = document.querySelector('.toolbar');
+                    const compareBtn = document.createElement('button');
+                    compareBtn.id = 'compareBtn';
+                    compareBtn.className = 'btn btn-primary';
+                    compareBtn.textContent = '🔄 元画像と比較';
+                    compareBtn.onclick = () => this.toggleComparison();
+                    toolbar.insertBefore(compareBtn, toolbar.firstChild);
+                }
+            }
+            
+            toggleComparison() {
+                if (this.beforeCropImage) {
+                    if (this.isShowingOriginal) {
+                        this.displayImage(this.currentImage);
+                        document.getElementById('compareBtn').textContent = '🔄 元画像と比較';
+                    } else {
+                        this.displayImage(this.beforeCropImage);
+                        document.getElementById('compareBtn').textContent = '📸 トリミング後を表示';
+                    }
+                    this.isShowingOriginal = !this.isShowingOriginal;
+                }
             }
             
             async cropTo10MB() {
@@ -687,9 +862,16 @@
             resetImage() {
                 if (this.originalImage) {
                     this.currentImage = this.originalImage;
+                    this.beforeCropImage = null;
+                    this.isShowingOriginal = false;
                     this.displayImage(this.originalImage);
-                    document.getElementById('cropOverlay').style.display = 'none';
-                    this.cropArea = null;
+                    this.exitCropMode();
+                    
+                    // 比較ボタンを削除
+                    const compareBtn = document.getElementById('compareBtn');
+                    if (compareBtn) {
+                        compareBtn.remove();
+                    }
                 }
             }
             

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "ai-sandbox-2025",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-sandbox-2025",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.54.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ai-sandbox-2025",
+  "version": "1.0.0",
+  "description": "AIを用いて架空のサイトを作るrepo このプロジェクトのデータは全て架空のものです。",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/s4na/ai-sandbox-2025.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/s4na/ai-sandbox-2025/issues"
+  },
+  "homepage": "https://github.com/s4na/ai-sandbox-2025#readme",
+  "devDependencies": {
+    "@playwright/test": "^1.54.2"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,19 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { 
+        browserName: 'chromium',
+      },
+    },
+  ],
+});

--- a/tests/15-image-trimmer.spec.js
+++ b/tests/15-image-trimmer.spec.js
@@ -1,0 +1,322 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+test.describe('架空の画像トリミングツール', () => {
+  test.beforeEach(async ({ page }) => {
+    // ローカルファイルを直接開く
+    await page.goto(`file://${path.resolve(__dirname, '../15/index.html')}`);
+  });
+
+  test('ページが正しく表示される', async ({ page }) => {
+    // タイトルが表示される
+    await expect(page.locator('h1')).toContainText('架空の画像トリミングツール');
+    
+    // ドロップゾーンが表示される
+    const dropZone = page.locator('#dropZone');
+    await expect(dropZone).toBeVisible();
+    await expect(dropZone).toContainText('画像をドラッグ&ドロップ');
+  });
+
+  test('画像をアップロードできる', async ({ page }) => {
+    // テスト用の画像を作成
+    const canvas = await page.evaluate(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 100;
+      canvas.height = 100;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'red';
+      ctx.fillRect(0, 0, 100, 100);
+      return canvas.toDataURL('image/png');
+    });
+    
+    // base64をBlobに変換してファイルとして扱う
+    await page.evaluate((dataUrl) => {
+      const arr = dataUrl.split(',');
+      const mime = arr[0].match(/:(.*?);/)[1];
+      const bstr = atob(arr[1]);
+      let n = bstr.length;
+      const u8arr = new Uint8Array(n);
+      while(n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+      const blob = new Blob([u8arr], {type: mime});
+      const file = new File([blob], 'test.png', {type: mime});
+      
+      // FileListを模擬
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      
+      // ファイル入力に設定
+      const fileInput = document.getElementById('fileInput');
+      fileInput.files = dataTransfer.files;
+      
+      // changeイベントを発火
+      const event = new Event('change', { bubbles: true });
+      fileInput.dispatchEvent(event);
+    }, canvas);
+    
+    // エディタが表示されるのを待つ
+    await expect(page.locator('#editorContainer')).toHaveClass(/active/);
+    
+    // キャンバスに画像が表示される
+    await expect(page.locator('#canvas')).toBeVisible();
+    
+    // サイズ表示が表示される
+    await expect(page.locator('#sizeDisplay')).toBeVisible();
+  });
+
+  test('各ボタンが存在し、クリック可能', async ({ page }) => {
+    // まず画像をアップロード
+    await page.evaluate(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 100;
+      canvas.height = 100;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'blue';
+      ctx.fillRect(0, 0, 100, 100);
+      const dataUrl = canvas.toDataURL('image/png');
+      
+      const arr = dataUrl.split(',');
+      const mime = arr[0].match(/:(.*?);/)[1];
+      const bstr = atob(arr[1]);
+      let n = bstr.length;
+      const u8arr = new Uint8Array(n);
+      while(n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+      const blob = new Blob([u8arr], {type: mime});
+      const file = new File([blob], 'test.png', {type: mime});
+      
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      
+      const fileInput = document.getElementById('fileInput');
+      fileInput.files = dataTransfer.files;
+      
+      const event = new Event('change', { bubbles: true });
+      fileInput.dispatchEvent(event);
+    });
+    
+    // エディタが表示されるのを待つ
+    await expect(page.locator('#editorContainer')).toHaveClass(/active/);
+    
+    // 各ボタンが存在してクリック可能
+    const buttons = [
+      '#cropFreeBtn',
+      '#crop10MBBtn',
+      '#downloadBtn',
+      '#resetBtn',
+      '#newImageBtn'
+    ];
+    
+    for (const buttonId of buttons) {
+      const button = page.locator(buttonId);
+      await expect(button).toBeVisible();
+      await expect(button).toBeEnabled();
+    }
+  });
+
+  test('品質スライダーが動作する', async ({ page }) => {
+    // 画像をアップロード
+    await page.evaluate(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 100;
+      canvas.height = 100;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'green';
+      ctx.fillRect(0, 0, 100, 100);
+      const dataUrl = canvas.toDataURL('image/png');
+      
+      const arr = dataUrl.split(',');
+      const mime = arr[0].match(/:(.*?);/)[1];
+      const bstr = atob(arr[1]);
+      let n = bstr.length;
+      const u8arr = new Uint8Array(n);
+      while(n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+      const blob = new Blob([u8arr], {type: mime});
+      const file = new File([blob], 'test.png', {type: mime});
+      
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      
+      const fileInput = document.getElementById('fileInput');
+      fileInput.files = dataTransfer.files;
+      
+      const event = new Event('change', { bubbles: true });
+      fileInput.dispatchEvent(event);
+    });
+    
+    await expect(page.locator('#editorContainer')).toHaveClass(/active/);
+    
+    // スライダーを操作
+    const slider = page.locator('#qualitySlider');
+    await expect(slider).toBeVisible();
+    
+    // 値を変更
+    await slider.fill('50');
+    await expect(page.locator('#qualityValue')).toHaveText('50');
+    
+    await slider.fill('100');
+    await expect(page.locator('#qualityValue')).toHaveText('100');
+  });
+
+  test('サイズ表示が更新される', async ({ page }) => {
+    // 画像をアップロード
+    await page.evaluate(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 200;
+      canvas.height = 200;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'yellow';
+      ctx.fillRect(0, 0, 200, 200);
+      const dataUrl = canvas.toDataURL('image/png');
+      
+      const arr = dataUrl.split(',');
+      const mime = arr[0].match(/:(.*?);/)[1];
+      const bstr = atob(arr[1]);
+      let n = bstr.length;
+      const u8arr = new Uint8Array(n);
+      while(n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+      const blob = new Blob([u8arr], {type: mime});
+      const file = new File([blob], 'test.png', {type: mime});
+      
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      
+      const fileInput = document.getElementById('fileInput');
+      fileInput.files = dataTransfer.files;
+      
+      const event = new Event('change', { bubbles: true });
+      fileInput.dispatchEvent(event);
+    });
+    
+    await expect(page.locator('#editorContainer')).toHaveClass(/active/);
+    
+    // サイズ表示が表示される
+    const sizeDisplay = page.locator('#sizeDisplay');
+    await expect(sizeDisplay).toBeVisible();
+    
+    // サイズ情報が表示される
+    await expect(page.locator('#currentSize')).toContainText('MB');
+    await expect(page.locator('#resolution')).toContainText('x');
+  });
+
+  test('新しい画像を選択ボタンが動作する', async ({ page }) => {
+    // 画像をアップロード
+    await page.evaluate(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 100;
+      canvas.height = 100;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'purple';
+      ctx.fillRect(0, 0, 100, 100);
+      const dataUrl = canvas.toDataURL('image/png');
+      
+      const arr = dataUrl.split(',');
+      const mime = arr[0].match(/:(.*?);/)[1];
+      const bstr = atob(arr[1]);
+      let n = bstr.length;
+      const u8arr = new Uint8Array(n);
+      while(n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+      const blob = new Blob([u8arr], {type: mime});
+      const file = new File([blob], 'test.png', {type: mime});
+      
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      
+      const fileInput = document.getElementById('fileInput');
+      fileInput.files = dataTransfer.files;
+      
+      const event = new Event('change', { bubbles: true });
+      fileInput.dispatchEvent(event);
+    });
+    
+    await expect(page.locator('#editorContainer')).toHaveClass(/active/);
+    
+    // 新しい画像を選択ボタンをクリック
+    await page.click('#newImageBtn');
+    
+    // ドロップゾーンが再表示される
+    await expect(page.locator('#dropZone')).toBeVisible();
+    await expect(page.locator('#editorContainer')).not.toHaveClass(/active/);
+  });
+
+  test('ダウンロードボタンが動作する', async ({ page }) => {
+    // 画像をアップロード
+    await page.evaluate(() => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 100;
+      canvas.height = 100;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = 'orange';
+      ctx.fillRect(0, 0, 100, 100);
+      const dataUrl = canvas.toDataURL('image/png');
+      
+      const arr = dataUrl.split(',');
+      const mime = arr[0].match(/:(.*?);/)[1];
+      const bstr = atob(arr[1]);
+      let n = bstr.length;
+      const u8arr = new Uint8Array(n);
+      while(n--) {
+        u8arr[n] = bstr.charCodeAt(n);
+      }
+      const blob = new Blob([u8arr], {type: mime});
+      const file = new File([blob], 'test.png', {type: mime});
+      
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      
+      const fileInput = document.getElementById('fileInput');
+      fileInput.files = dataTransfer.files;
+      
+      const event = new Event('change', { bubbles: true });
+      fileInput.dispatchEvent(event);
+    });
+    
+    await expect(page.locator('#editorContainer')).toHaveClass(/active/);
+    
+    // ダウンロードイベントを監視
+    const downloadPromise = page.waitForEvent('download');
+    
+    // ダウンロード関数をモック
+    await page.evaluate(() => {
+      // URL.createObjectURLとrevokeObjectURLをモック
+      const originalCreateObjectURL = URL.createObjectURL;
+      const originalRevokeObjectURL = URL.revokeObjectURL;
+      let createdUrl = null;
+      
+      URL.createObjectURL = (blob) => {
+        createdUrl = 'blob:mock-url';
+        return createdUrl;
+      };
+      
+      URL.revokeObjectURL = (url) => {
+        // モック実装
+      };
+      
+      // クリックイベントをキャプチャしてダウンロードが呼ばれたことを確認
+      window.downloadCalled = false;
+      const originalClick = HTMLAnchorElement.prototype.click;
+      HTMLAnchorElement.prototype.click = function() {
+        if (this.download && this.download.includes('trimmed_image')) {
+          window.downloadCalled = true;
+        }
+        // 実際のクリックは実行しない（ダウンロードダイアログを避ける）
+      };
+    });
+    
+    // ダウンロードボタンをクリック
+    await page.click('#downloadBtn');
+    
+    // ダウンロード関数が呼ばれたことを確認
+    const downloadCalled = await page.evaluate(() => window.downloadCalled);
+    expect(downloadCalled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- トリミング機能のユーザビリティを大幅に改善
- 範囲選択の視覚的フィードバックを強化
- トリミング前後の比較機能を追加

## 主な改善点

### 🎯 トリミングモードの明確化
- 右上に「トリミングモード」インジケーターを表示
- 画面下部に操作指示をリアルタイム表示
- モード中であることが一目で分かる

### 📐 選択範囲の視覚的改善
- 選択範囲外を半透明の黒で覆い、範囲を明確化
- 破線のアニメーションで選択中を強調
- どこを切り取るかが明確に

### ✂️ 操作フローの改善
- マウスを離してもすぐに確定しない仕様に変更
- 「トリミング確定」「キャンセル」ボタンを追加
- 範囲選択後に調整や取り消しが可能

### 🔄 トリミング後の確認機能
- 「元画像と比較」ボタンを新規追加
- ワンクリックでトリミング前後を切り替え
- どこを切り取ったかを確認可能

## Test plan
- [ ] 画像をアップロードできることを確認
- [ ] 「自由サイズでトリミング」ボタンでトリミングモードに入ることを確認
- [ ] ドラッグで範囲選択ができることを確認
- [ ] 選択範囲が視覚的に分かりやすいことを確認
- [ ] 「トリミング確定」「キャンセル」ボタンが動作することを確認
- [ ] トリミング後に「元画像と比較」ボタンが表示されることを確認
- [ ] 比較ボタンで画像が切り替わることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)