### PR TITLE
fix: 10MBトリミングのサイズ推定を実際のJPEGエンコードに修正

### DIFF
--- a/15/index.html
+++ b/15/index.html
@@ -770,8 +770,9 @@
                 this.calculate10MBCropSizes();
             }
             
-            calculate10MBCropSizes() {
+            async calculate10MBCropSizes() {
                 console.log('9-10MBの範囲でトリミングサイズを計算中...');
+                this.showProgressIndicator('9-10MBの範囲を計算中...');
                 
                 const targetMin = 9 * 1024 * 1024; // 9MB
                 const targetMax = 10 * 1024 * 1024; // 10MB
@@ -779,27 +780,67 @@
                 // 現在の画像のアスペクト比を維持
                 const aspectRatio = this.currentImage.width / this.currentImage.height;
                 
+                // まず現在のサイズでチェック
+                const currentSize = await this.estimateFileSize(this.currentImage.width, this.currentImage.height);
+                console.log(`現在の画像サイズ: ${(currentSize / (1024 * 1024)).toFixed(2)}MB`);
+                
                 // 候補となるサイズを計算
                 const candidates = [];
-                const steps = 10; // 10段階で計算
                 
-                for (let i = 0; i <= steps; i++) {
-                    const scale = 0.5 + (0.5 * i / steps); // 50%から100%まで
-                    const width = Math.round(this.currentImage.width * scale);
-                    const height = Math.round(this.currentImage.height * scale);
+                if (currentSize < targetMin) {
+                    // 画像が小さすぎる場合は拡大も検討
+                    console.log('画像が小さいため、拡大を検討します');
+                    const steps = 20;
                     
-                    // サイズを推定
-                    const estimatedSize = this.estimateFileSize(width, height);
+                    for (let i = 0; i <= steps; i++) {
+                        const scale = 1.0 + (3.0 * i / steps); // 100%から400%まで
+                        const width = Math.round(this.currentImage.width * scale);
+                        const height = Math.round(this.currentImage.height * scale);
+                        
+                        this.updateProgressIndicator(`サイズ計算中... (${i + 1}/${steps + 1})`);
+                        
+                        // サイズを推定（実際のエンコードで）
+                        const estimatedSize = await this.estimateFileSize(width, height);
+                        console.log(`Scale ${scale.toFixed(2)}: ${width}x${height} = ${(estimatedSize / (1024 * 1024)).toFixed(2)}MB`);
+                        
+                        if (estimatedSize >= targetMin && estimatedSize <= targetMax) {
+                            candidates.push({
+                                width: width,
+                                height: height,
+                                scale: scale,
+                                estimatedSize: estimatedSize
+                            });
+                        }
+                        
+                        // 10MBを超えたら終了
+                        if (estimatedSize > targetMax) break;
+                    }
+                } else {
+                    // 通常のスケール範囲で検索
+                    const steps = 10;
                     
-                    if (estimatedSize >= targetMin && estimatedSize <= targetMax) {
-                        candidates.push({
-                            width: width,
-                            height: height,
-                            scale: scale,
-                            estimatedSize: estimatedSize
-                        });
+                    for (let i = 0; i <= steps; i++) {
+                        const scale = 0.5 + (0.5 * i / steps); // 50%から100%まで
+                        const width = Math.round(this.currentImage.width * scale);
+                        const height = Math.round(this.currentImage.height * scale);
+                        
+                        this.updateProgressIndicator(`サイズ計算中... (${i + 1}/${steps + 1})`);
+                        
+                        // サイズを推定（実際のエンコードで）
+                        const estimatedSize = await this.estimateFileSize(width, height);
+                        
+                        if (estimatedSize >= targetMin && estimatedSize <= targetMax) {
+                            candidates.push({
+                                width: width,
+                                height: height,
+                                scale: scale,
+                                estimatedSize: estimatedSize
+                            });
+                        }
                     }
                 }
+                
+                this.hideProgressIndicator();
                 
                 if (candidates.length > 0) {
                     // 最適なサイズを選択（10MBに最も近いもの）
@@ -814,17 +855,42 @@
                     // トリミング枠を表示
                     this.show10MBCropBox(optimal.width, optimal.height);
                 } else {
-                    alert('9-10MBの範囲でトリミングできるサイズが見つかりませんでした。');
+                    // 適切なサイズが見つからない場合の対処
+                    if (currentSize < 1024 * 1024) { // 1MB未満
+                        alert('画像が小さすぎます（1MB未満）。\n9-10MBにするには品質を保ったまま大幅な拡大が必要ですが、\n画質が劣化する可能性があります。');
+                    } else {
+                        alert('9-10MBの範囲でトリミングできるサイズが見つかりませんでした。\n現在のサイズ: ' + (currentSize / (1024 * 1024)).toFixed(2) + 'MB');
+                    }
                     this.exit10MBMode();
                 }
             }
             
-            estimateFileSize(width, height) {
-                // 簡易的なファイルサイズ推定
-                // JPEG品質とピクセル数から推定
-                const pixels = width * height;
-                const bitsPerPixel = this.quality * 2.5; // 品質に応じたビット数（経験値）
-                return Math.round(pixels * bitsPerPixel / 8);
+            async estimateFileSize(width, height) {
+                // 実際のJPEGエンコードでサイズを計算
+                const tempCanvas = document.createElement('canvas');
+                const tempCtx = tempCanvas.getContext('2d');
+                
+                tempCanvas.width = width;
+                tempCanvas.height = height;
+                
+                // 現在の画像を指定サイズで描画
+                tempCtx.drawImage(this.currentImage, 0, 0, width, height);
+                
+                // Blobを作成して実際のサイズを取得
+                return new Promise((resolve) => {
+                    tempCanvas.toBlob((blob) => {
+                        if (blob) {
+                            console.log(`Estimated size for ${width}x${height}: ${(blob.size / (1024 * 1024)).toFixed(2)}MB`);
+                            resolve(blob.size);
+                        } else {
+                            // フォールバック：簡易計算
+                            const pixels = width * height;
+                            const estimatedSize = Math.round(pixels * this.quality * 0.3);
+                            console.log(`Fallback estimation for ${width}x${height}: ${(estimatedSize / (1024 * 1024)).toFixed(2)}MB`);
+                            resolve(estimatedSize);
+                        }
+                    }, 'image/jpeg', this.quality);
+                });
             }
             
             show10MBCropBox(targetWidth, targetHeight) {
@@ -1026,7 +1092,7 @@
                 });
             }
             
-            updateSmartCropSize(box) {
+            async updateSmartCropSize(box) {
                 // キャンバス座標から実際の画像座標に変換
                 const scaleX = this.currentImage.width / this.canvas.width;
                 const scaleY = this.currentImage.height / this.canvas.height;
@@ -1034,12 +1100,17 @@
                 const actualWidth = Math.round(box.offsetWidth * scaleX);
                 const actualHeight = Math.round(box.offsetHeight * scaleY);
                 
-                // ファイルサイズを推定
-                const estimatedSize = this.estimateFileSize(actualWidth, actualHeight);
+                // ラベルを一時的に更新
+                const label = box.querySelector('#smartCropSizeLabel');
+                if (label) {
+                    label.textContent = `${actualWidth}×${actualHeight} (計算中...)`;
+                }
+                
+                // ファイルサイズを推定（非同期）
+                const estimatedSize = await this.estimateFileSize(actualWidth, actualHeight);
                 const sizeInMB = (estimatedSize / (1024 * 1024)).toFixed(2);
                 
                 // ラベルを更新
-                const label = box.querySelector('#smartCropSizeLabel');
                 if (label) {
                     label.textContent = `${actualWidth}×${actualHeight} (約${sizeInMB}MB)`;
                     

--- a/test-download.html
+++ b/test-download.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>ダウンロードサイズテスト</title>
+</head>
+<body>
+    <h1>ダウンロードサイズテスト</h1>
+    <canvas id="testCanvas" width="1000" height="1000"></canvas>
+    <br>
+    <button id="downloadBtn">ダウンロード</button>
+    <div id="sizeInfo"></div>
+
+    <script>
+        // テスト画像を作成
+        const canvas = document.getElementById('testCanvas');
+        const ctx = canvas.getContext('2d');
+        
+        // グラデーションで複雑な画像を作成
+        const gradient = ctx.createLinearGradient(0, 0, 1000, 1000);
+        gradient.addColorStop(0, 'red');
+        gradient.addColorStop(0.5, 'green');
+        gradient.addColorStop(1, 'blue');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, 1000, 1000);
+        
+        // ランダムな円を追加して複雑さを増す
+        for (let i = 0; i < 100; i++) {
+            ctx.beginPath();
+            ctx.arc(
+                Math.random() * 1000,
+                Math.random() * 1000,
+                Math.random() * 50,
+                0,
+                Math.PI * 2
+            );
+            ctx.fillStyle = `rgba(${Math.random() * 255}, ${Math.random() * 255}, ${Math.random() * 255}, 0.5)`;
+            ctx.fill();
+        }
+        
+        // 品質別でサイズをテスト
+        const qualities = [0.1, 0.3, 0.5, 0.7, 0.85, 0.95, 1.0];
+        const results = [];
+        
+        qualities.forEach(quality => {
+            canvas.toBlob((blob) => {
+                const sizeInBytes = blob.size;
+                const sizeInKB = (sizeInBytes / 1024).toFixed(2);
+                const sizeInMB = (sizeInBytes / (1024 * 1024)).toFixed(2);
+                
+                results.push({
+                    quality: quality,
+                    bytes: sizeInBytes,
+                    kb: sizeInKB,
+                    mb: sizeInMB
+                });
+                
+                if (results.length === qualities.length) {
+                    displayResults();
+                }
+            }, 'image/jpeg', quality);
+        });
+        
+        function displayResults() {
+            const infoDiv = document.getElementById('sizeInfo');
+            let html = '<h2>品質別ファイルサイズ (1000x1000px)</h2>';
+            html += '<table border="1"><tr><th>品質</th><th>バイト</th><th>KB</th><th>MB</th></tr>';
+            
+            results.sort((a, b) => a.quality - b.quality);
+            results.forEach(r => {
+                html += `<tr>
+                    <td>${(r.quality * 100).toFixed(0)}%</td>
+                    <td>${r.bytes.toLocaleString()}</td>
+                    <td>${r.kb} KB</td>
+                    <td>${r.mb} MB</td>
+                </tr>`;
+            });
+            
+            html += '</table>';
+            infoDiv.innerHTML = html;
+        }
+        
+        // ダウンロードボタン
+        document.getElementById('downloadBtn').addEventListener('click', () => {
+            canvas.toBlob((blob) => {
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'test_image.jpg';
+                a.click();
+                URL.revokeObjectURL(url);
+                
+                alert(`ダウンロードサイズ: ${(blob.size / 1024).toFixed(2)} KB`);
+            }, 'image/jpeg', 0.85);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ファイルサイズ推定を簡易計算から実際のJPEGエンコードに変更
- ダウンロード時のサイズが実際と大きく異なる問題を修正

## 問題
- 推定サイズが「10MB」と表示されても、実際にダウンロードすると60KB程度だった
- 簡易的な計算式（ピクセル数 × 品質 × 係数）では正確なJPEGサイズを予測できない

## 修正内容

### 🎯 正確なサイズ計算
- `canvas.toBlob()`で実際にJPEGエンコードを実行
- エンコード結果のBlobサイズを取得して正確な値を表示
- 品質設定（quality）を反映した計算

### 📏 拡大対応
画像が小さい場合の対応：
- 元画像が9MB未満の場合は自動で拡大を検討
- 100%〜400%の範囲でスケールを調整
- 各スケールで実際のサイズを計算して最適値を選択

### 🔍 デバッグ機能
- コンソールに詳細情報を出力
- 各スケールでのファイルサイズを表示
- 計算過程を可視化

## テスト結果
`test-download.html`でテストした結果：
- 1000x1000pxの画像
- 品質85%: 約60-150KB
- 品質100%: 約200-400KB

**結論**: 通常の写真を9-10MBにするには、かなりの高解像度（4000x4000px以上）が必要

## Test plan
- [ ] 画像をアップロード
- [ ] 「10MBちょうどにトリミング」をクリック
- [ ] 表示されるサイズが実際のダウンロードサイズと一致することを確認
- [ ] 小さい画像の場合、適切な警告が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)