### PR TITLE
fix: インデックスページのリスト表示順を新しい順に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,9 @@
                 pageListEl.style.display = 'none';
                 noPageEl.style.display = 'block';
             } else {
-                pageListEl.innerHTML = pages.map(createPageCard).join('');
+                // 逆順にして表示
+                const reversedPages = [...pages].reverse();
+                pageListEl.innerHTML = reversedPages.map(createPageCard).join('');
                 pageListEl.style.display = 'grid';
                 noPageEl.style.display = 'none';
                 


### PR DESCRIPTION
## Summary
- インデックスページのページリストを新しい順（降順）で表示するように変更

## 変更内容
- `index.html`のdisplayPages関数を修正
- ページ配列を逆順にしてから表示するように変更
- 最新のページが上部に表示されるようになり、ユーザビリティが向上

## Test plan
- [ ] インデックスページが正常に表示されることを確認
- [ ] ページリストが新しい順で表示されることを確認
- [ ] スキャン情報が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)